### PR TITLE
FINDING-7215 Adding Mocha before/after support

### DIFF
--- a/jasmine.js
+++ b/jasmine.js
@@ -6,13 +6,16 @@ module.exports = {
     ],
     "env": {
         "jasmine": true,
-        "phantomjs": true
+        "phantomjs": true,
+        "mocha": true
     },
     "globals": {
         "loadFixtures": false,
         "appendLoadFixtures": false,
         "setFixtures": false,
-        "sandbox": false
+        "sandbox": false,
+        "before": false,
+        "after": false
     },
     "rules": {
         "jasmine/no-suite-dupes": [1, "branch"],


### PR DESCRIPTION
Mocha uses `before` and `after` in place of Jasmine's `beforeAll` and `afterAll`.

cc @robrichard 