### PR TITLE
enabled ecma-features in es6 config

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = {
+    ecmaFeatures: {
+        modules: true
+    },
     "env": {
         "es6": true
     },


### PR DESCRIPTION
linter was complaining about perfectly fine `import` statements like:
```js
import React {PropTypes} from 'react';
```