### PR TITLE
add support for resolving additional extensions for require-path-exists plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
         "require-path-exists"
     ],
     "rules": {
-        "require-path-exists/exists": 1,
+        "require-path-exists/exists": [1, { "extensions": [".es.js", ".jsx", ".html"] }],
         "require-path-exists/notEmpty": 1,
         "require-path-exists/tooManyArguments": 1,
         "no-bitwise": 2,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "peerDependencies": {
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.2.0",
-    "eslint-plugin-jasmine": "^1.4.0"
+    "eslint-plugin-jasmine": "^1.4.0",
+    "eslint-plugin-require-path-exists": "git+ssh://git@github.com:1stdibs/eslint-plugin-require-path-exists.git#file-ext-whitelist"
   }
 }


### PR DESCRIPTION
Depends on dibslint PR: https://github.com/1stdibs/dibslint/pull/10
Related plugin fork PR: https://github.com/lilianammmatos/eslint-plugin-require-path-exists/pull/1