### PR TITLE
Changed sourceType to 'module' and disabled 'strict' rule for es6 and…

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -7,12 +7,13 @@ module.exports = {
     ],
     "parser": "babel-eslint",
     "parserOptions": {
-        "sourceType": "script"
+        "sourceType": "module"
     },
     "env": {
         "es6": true
     },
     "rules": {
+        "strict": 0,
         "flow-vars/define-flow-type": 1,
         "flow-vars/use-flow-type": 1,
         "constructor-super": 2,


### PR DESCRIPTION
… above, to allow flow import/export type

Flow doesn't have a commonjs way to share common type aliases, it only allows es6 module syntax. It's safe to disable the 'use strict' rule for es6 and above since babel-loader automatically inserts 'use strict' at the top of every module. ES5 will still throw a warning if 'use strict' is not present.