### PR TITLE
remove default export rule

### DIFF
--- a/packages/eslint-config-1stdibs-base/rules/import.js
+++ b/packages/eslint-config-1stdibs-base/rules/import.js
@@ -27,7 +27,6 @@ module.exports = {
                 "js": "never",
                 "jsx": "never"
             }
-        ],
-        "import/no-default-export": "warn",
+        ]
     }
 };


### PR DESCRIPTION
IMO this rule is too burdensome on our engineers. Making any change in a file that currently has a default export will require you to update that file, as well as the consumers of that file, as well as the consumers of those consumers and so on. It is very likely that this will spiral out of control and cause you to either need to make a large, error-prone, sweeping change across the codebase or ignore the lint rules entirely. 

I think keeping this here will make ignoring precommit rules a more common practice and therefore lessen the value of the existing rules.