### PR TITLE
FINDING-12817 - Add rel noopener noreferrer

### DIFF
--- a/packages/eslint-config-1stdibs/rules/react.js
+++ b/packages/eslint-config-1stdibs/rules/react.js
@@ -39,6 +39,7 @@ module.exports = {
         "react/self-closing-comp": 2,
         "react/sort-comp": 1,
         "react/prefer-es6-class": [1, "always"],
-        "react/prefer-stateless-function": 1
+        "react/prefer-stateless-function": 1,
+        "react/jsx-no-target-blank": 2
     }
 };


### PR DESCRIPTION
About the rule https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md

Notice that it also enforces `noreferrer`, that means HTTP referrer header will not be sent.

[Some more info about it](https://support.performancefoundry.com/article/186-noopener-noreferrer-on-my-links)
[How it affects GA](https://www.3whitehats.com/knowledge/wordpress-noreferrer-google-analytics/)
