### PR TITLE
need to add flowtype back

### DIFF
--- a/packages/eslint-config-1stdibs/index.js
+++ b/packages/eslint-config-1stdibs/index.js
@@ -1,4 +1,5 @@
 module.exports = {
-    extends: ['eslint-config-1stdibs-base', './rules/react'].map(require.resolve),
-    rules: {},
+    extends: ['eslint-config-1stdibs-base', './rules/react', './rules/flowtype'].map(
+        require.resolve
+    ),
 };

--- a/packages/eslint-config-1stdibs/package.json
+++ b/packages/eslint-config-1stdibs/package.json
@@ -14,6 +14,7 @@
     "@typescript-eslint/parser": "^1.9.0",
     "eslint-config-1stdibs-base": "^2.0.0",
     "eslint-config-prettier": "^4.3.0",
+    "eslint-plugin-flowtype": "^3.9.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.11.0",
     "eslint-plugin-react-hooks": "^1.6.0",

--- a/packages/eslint-config-1stdibs/rules/flowtype.js
+++ b/packages/eslint-config-1stdibs/rules/flowtype.js
@@ -1,0 +1,24 @@
+module.exports = {
+    plugins: ['flowtype'],
+    parser: 'babel-eslint',
+    parserOptions: {
+        sourceType: 'module',
+    },
+    env: {
+        es6: true,
+    },
+    rules: {
+        'flowtype/define-flow-type': 'warn',
+        'flowtype/use-flow-type': 'warn',
+        'flowtype/boolean-style': ['warn', 'boolean'],
+        'flowtype/no-dupe-keys': 'warn',
+        'flowtype/no-primitive-constructor-types': 'warn',
+        'flowtype/no-types-missing-file-annotation': 'warn',
+        'flowtype/require-valid-file-annotation': ['warn', 'never'],
+    },
+    settings: {
+        flowtype: {
+            onlyFilesWithFlowAnnotation: true,
+        },
+    },
+};

--- a/packages/eslint-config-1stdibs/yarn.lock
+++ b/packages/eslint-config-1stdibs/yarn.lock
@@ -397,6 +397,13 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-flowtype@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.9.1.tgz#6491d930e1f96d53c510e0393e635fddd4a4cac5"
+  integrity sha512-ZlV6SbIXqz2ysvG0F64ZH07dqzLrwMdM1s0UNfoxdXjr4kMKuPPoLViwK+gFC952QIf341AmP4BKtKOhcB96Ug==
+  dependencies:
+    lodash "^4.17.11"
+
 eslint-plugin-import@^2.8.0:
   version "2.17.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"


### PR DESCRIPTION
- this is needed while migrating to ts

I need to merge this sooner than later b/c this is a  blocker for getting ts integrations (fails jenkins builds). Ultimately, this will be removed but it seems like we need to keep these until we are 💯off of flow.