### PR TITLE
eslint-config-1stdibs: removed ts prettier rules

### DIFF
--- a/packages/eslint-config-1stdibs/typescript.js
+++ b/packages/eslint-config-1stdibs/typescript.js
@@ -7,7 +7,4 @@ module.exports = {
         './rules/react.js',
     ],
     plugins: ['eslint-plugin-prettier'],
-    rules: {
-        'prettier/prettier': 'error',
-    },
 };


### PR DESCRIPTION
having these rules would result in lint errors like the following:
```
/Users/daletan/projects/app-admin-cms/src/createType/CreateNewType.tsx
40:27  error  Delete `⏎························`                                              prettier/prettier
42:1   error  Delete `····`                                                                   prettier/prettier
43:1   error  Delete `····`                                                                   prettier/prettier
44:1   error  Replace `································` with `····························`  prettier/prettier
45:1   error  Delete `····`                                                                   prettier/prettier
46:21  error  Replace `····}⏎····················` with `}`                                   prettier/prettier
48:28  error  Delete `⏎························`                                              prettier/prettier
50:25  error  Delete `····`                                                                   prettier/prettier
51:1   error  Delete `····`                                                                   prettier/prettier
52:33  error  Delete `····`                                                                   prettier/prettier
53:1   error  Replace `································` with `····························`  prettier/prettier
54:1   error  Delete `····`                                                                   prettier/prettier
55:25  error  Delete `····`                                                                   prettier/prettier
56:21  error  Replace `····}⏎····················` with `}`                                   prettier/prettier
```