### PR TITLE
add no-array-index-key rule

### DIFF
--- a/packages/eslint-config-1stdibs/rules/react.js
+++ b/packages/eslint-config-1stdibs/rules/react.js
@@ -33,6 +33,7 @@ module.exports = {
         'react/jsx-no-target-blank': 'warn',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'warn',
+        'react/no-array-index-key': 'warn',
         // relay
         'relay/graphql-syntax': 'warn',
         'relay/no-future-added-value': 'warn',


### PR DESCRIPTION
Rule to show a warning when array `index` is being used to generate React `key` attribute.

```jsx
{[1, 2, 3, 4, 5].map((value, index) => {
    return <div key={index}>{value}</div>;
})}
```
will result with a warning:
```
(parameter) index: number
Do not use Array index in keys eslint(react/no-array-index-key)
```

More info:
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md