### PR TITLE
FI-1632 warn on console methods

### DIFF
--- a/packages/eslint-config-1stdibs-base/rules/bestPractices.js
+++ b/packages/eslint-config-1stdibs-base/rules/bestPractices.js
@@ -1,5 +1,6 @@
 module.exports = {
     rules: {
+        'no-console': 'warn',
         'block-scoped-var': 'error',
         'consistent-return': 'warn',
         curly: 'error',


### PR DESCRIPTION
We're no longer going to be stripping all `console` methods in production builds. This should mitigate developers mistakenly adding extraneous calls.