### PR TITLE
FI-1769 Remove rules requiring React in scope for JSX

### DIFF
--- a/packages/eslint-config-1stdibs/rules/react.js
+++ b/packages/eslint-config-1stdibs/rules/react.js
@@ -15,7 +15,6 @@ module.exports = {
         'react/jsx-boolean-value': 'warn',
         'react/jsx-no-duplicate-props': 'error',
         'react/jsx-no-undef': 'error',
-        'react/jsx-uses-react': 'error',
         'react/jsx-uses-vars': 'error',
         'react/no-multi-comp': [
             'error',
@@ -25,7 +24,6 @@ module.exports = {
         ],
         'react/no-unknown-property': 'error',
         'react/prop-types': 'warn',
-        'react/react-in-jsx-scope': 'error',
         'react/self-closing-comp': 'error',
         'react/sort-comp': 'warn',
         'react/prefer-es6-class': ['warn', 'always'],


### PR DESCRIPTION
I'm going to be updating the jsx transform to "automatic" which does not require React to be in scope to use JSX