### PR TITLE
Add No Unnecessary Condition to TS Rules

### DIFF
--- a/packages/eslint-config-1stdibs/typescript.js
+++ b/packages/eslint-config-1stdibs/typescript.js
@@ -12,6 +12,7 @@ module.exports = {
         '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/no-explicit-any': 'warn',
+        '@typescript-eslint/no-unnecessary-condition': 'warn',
         '@typescript-eslint/prefer-interface': 'off',
         '@typescript-eslint/explicit-function-return-type': [
             'error',


### PR DESCRIPTION
### Description:
Added [TS rule `no-unnecessary-condition` ](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md#no-unnecessary-condition). This will hopefully make the code a bit cleaner.

[Link here to the original Slack discussion.](https://1stdibs.slack.com/archives/C0507PFD7/p1654714172388229)

*Tested and works as expected.

### Concerns:
As mentioned by @brettjashford:

Something to keep an eye on is this keeps you from optional chaining if it thinks it can't be `null`:
```
function bar<T>(arg: string) {
  // arg can never be nullish, so ?. is unnecessary
  return arg?.length;
}
```
This could be an issue in places like `dibs-graphql` where we create types for rest endpoint responses that might not be completely accurate. Its more an issue with our types and could be solved by using something like [DeepNullable](https://typeofnan.dev/making-every-object-property-nullable-in-typescript/) (recursive types :exploding_head:) to make them more like relay generated types.