### PR TITLE
Removed No Unnecessary Condition to TS Rules

### DIFF
--- a/packages/eslint-config-1stdibs/package.json
+++ b/packages/eslint-config-1stdibs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-1stdibs",
   "github": "https://github.com/1stdibs/eslint-config-1stdibs",
-  "version": "7.1.3",
+  "version": "7.1.2",
   "description": "ESLint configurations for 1stdibs projects.",
   "main": "index.js",
   "author": "1stdibs <npm@1stdibs.com> (https://1stdibs.com)",

--- a/packages/eslint-config-1stdibs/typescript.js
+++ b/packages/eslint-config-1stdibs/typescript.js
@@ -12,7 +12,6 @@ module.exports = {
         '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/no-explicit-any': 'warn',
-        '@typescript-eslint/no-unnecessary-condition': 'warn',
         '@typescript-eslint/prefer-interface': 'off',
         '@typescript-eslint/explicit-function-return-type': [
             'error',


### PR DESCRIPTION
### Description:
Removed [TS rule `no-unnecessary-condition` ](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md#no-unnecessary-condition). 

[Link here to the original Slack discussion.](https://1stdibs.slack.com/archives/C0507PFD7/p1654714172388229)
[Link here to the follow on Slack discussion.](https://1stdibs.slack.com/archives/C0507PFD7/p1656673582175099)

Removed because our inclusion of TS and JS conflicts and will cause runtime errors if incorrect.